### PR TITLE
Update app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,6 @@
     },
     "assetBundlePatterns": ["**/*"],
     "plugins": [
-      "./plugins/withAndroidShareExtension",
       [
         "./plugins/withAndroidShareExtension/index",
         {


### PR DESCRIPTION
Delete the duplicate line.
I built with it first and for image sharing the app was not present on the sheet for android.
Since it's not the right format to call the plugin, I removed it and everything works perfectly now.