### PR TITLE
fix: pending callbacks

### DIFF
--- a/hooks/useShareIntent.js
+++ b/hooks/useShareIntent.js
@@ -29,6 +29,9 @@ export default function useShareIntent() {
     console.log("useShareIntent[mount]", Constants.expoConfig.scheme);
     ReceiveSharingIntent?.getReceivedFiles(
       (data) => {
+        if(!data || data.intent.length === 0) {
+          console.log("useShareIntent[mount] no share intent detected");
+          return;        }
         const intent = data[0];
         if (intent.weblink || intent.text) {
           const link = intent.weblink || intent.text || "";

--- a/patches/react-native-receive-sharing-intent+2.0.0.patch
+++ b/patches/react-native-receive-sharing-intent+2.0.0.patch
@@ -1,5 +1,166 @@
+diff --git a/node_modules/react-native-receive-sharing-intent/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java b/node_modules/react-native-receive-sharing-intent/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
+index 69126eb..b15059a 100644
+--- a/node_modules/react-native-receive-sharing-intent/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
++++ b/node_modules/react-native-receive-sharing-intent/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentHelper.java
+@@ -26,83 +26,92 @@ public class ReceiveSharingIntentHelper {
+     this.context = context;
+   }
+ 
+-  @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+-  public void sendFileNames(Context context, Intent intent, Promise promise){
+-    try {
+-      String action = intent.getAction();
+-      String type = intent.getType();
+-      if(type == null) { return; }
+-      if(!type.startsWith("text") && (Objects.equals(action, Intent.ACTION_SEND) || Objects.equals(action, Intent.ACTION_SEND_MULTIPLE))){
++@RequiresApi(api = Build.VERSION_CODES.KITKAT)
++public void sendFileNames(Context context, Intent intent, Promise promise){
++  try {
++    String action = intent.getAction();
++    String type = intent.getType();
++    if(type == null) { 
++      promise.reject();
++      return; 
++    }
++    if(!type.startsWith("text") && (Objects.equals(action, Intent.ACTION_SEND) || Objects.equals(action, Intent.ACTION_SEND_MULTIPLE))){
++      WritableMap files = getMediaUris(intent,context);
++      if(files == null) {
++        promise.reject();
++        return;
++      }
++      promise.resolve(files);
++    }else if(type.startsWith("text") && Objects.equals(action, Intent.ACTION_SEND)){
++      String text = null;
++      String subject = null;
++      try{
++        text = intent.getStringExtra(Intent.EXTRA_TEXT);
++        subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
++      }catch (Exception ignored){ }
++      if(text == null){
+         WritableMap files = getMediaUris(intent,context);
+-        if(files == null) return;
+-        promise.resolve(files);
+-      }else if(type.startsWith("text") && Objects.equals(action, Intent.ACTION_SEND)){
+-        String text = null;
+-        String subject = null;
+-        try{
+-          text = intent.getStringExtra(Intent.EXTRA_TEXT);
+-          subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
+-        }catch (Exception ignored){ }
+-        if(text == null){
+-          WritableMap files = getMediaUris(intent,context);
+-          if(files == null) return;
+-          promise.resolve(files);
+-        }else{
+-          WritableMap files = new WritableNativeMap();
+-          WritableMap file = new WritableNativeMap();
+-          file.putString("contentUri",null);
+-          file.putString("filePath", null);
+-          file.putString("fileName", null);
+-          file.putString("extension", null);
+-          if(text.startsWith("http")){
+-            file.putString("weblink", text);
+-            file.putString("text",null);
+-          }else{
+-            file.putString("weblink", null);
+-            file.putString("text",text);
+-          }
+-          file.putString("subject", subject);
+-          files.putMap("0",file);
+-          promise.resolve(files);
++        if(files == null) {
++          promise.reject();
++          return;
+         }
+-
+-      }else if(Objects.equals(action, Intent.ACTION_VIEW)){
+-        String link = intent.getDataString();
++        promise.resolve(files);
++      }else{
+         WritableMap files = new WritableNativeMap();
+         WritableMap file = new WritableNativeMap();
+         file.putString("contentUri",null);
+         file.putString("filePath", null);
+-        file.putString("mimeType",null);
+-        file.putString("text",null);
+-        file.putString("weblink", link);
+         file.putString("fileName", null);
+         file.putString("extension", null);
++        if(text.startsWith("http")){
++          file.putString("weblink", text);
++          file.putString("text",null);
++        }else{
++          file.putString("weblink", null);
++          file.putString("text",text);
++        }
++        file.putString("subject", subject);
+         files.putMap("0",file);
+         promise.resolve(files);
+       }
+-      else if (Objects.equals(action, "android.intent.action.PROCESS_TEXT")) {
+-        String text = null;
+-        try {
+-          text = intent.getStringExtra(intent.EXTRA_PROCESS_TEXT);
+-        } catch (Exception e) {
+-        }
+-          WritableMap files = new WritableNativeMap();
+-          WritableMap file = new WritableNativeMap();
+-          file.putString("contentUri", null);
+-          file.putString("filePath", null);
+-          file.putString("fileName", null);
+-          file.putString("extension", null);
+-          file.putString("weblink", null);
+-          file.putString("text", text);
+-          files.putMap("0", file);
+-          promise.resolve(files);
+-      }else{
+-        promise.reject("error","Invalid file type.");
++
++    }else if(Objects.equals(action, Intent.ACTION_VIEW)){
++      String link = intent.getDataString();
++      WritableMap files = new WritableNativeMap();
++      WritableMap file = new WritableNativeMap();
++      file.putString("contentUri",null);
++      file.putString("filePath", null);
++      file.putString("mimeType",null);
++      file.putString("text",null);
++      file.putString("weblink", link);
++      file.putString("fileName", null);
++      file.putString("extension", null);
++      files.putMap("0",file);
++      promise.resolve(files);
++    }
++    else if (Objects.equals(action, "android.intent.action.PROCESS_TEXT")) {
++      String text = null;
++      try {
++        text = intent.getStringExtra(intent.EXTRA_PROCESS_TEXT);
++      } catch (Exception e) {
+       }
+-    }catch (Exception e){
+-      promise.reject("error",e.toString());
++      WritableMap files = new WritableNativeMap();
++      WritableMap file = new WritableNativeMap();
++      file.putString("contentUri", null);
++      file.putString("filePath", null);
++      file.putString("fileName", null);
++      file.putString("extension", null);
++      file.putString("weblink", null);
++      file.putString("text", text);
++      files.putMap("0", file);
++      promise.resolve(files);
++    }else{
++      promise.reject();
+     }
+-  };
++  }catch (Exception e){
++    promise.reject();
++  }
++};
+ 
+ 
+   @RequiresApi(api = Build.VERSION_CODES.KITKAT)
 diff --git a/node_modules/react-native-receive-sharing-intent/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java b/node_modules/react-native-receive-sharing-intent/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java
-index f752144..725918a 100644
+index f752144..f0bd892 100644
 --- a/node_modules/react-native-receive-sharing-intent/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java
 +++ b/node_modules/react-native-receive-sharing-intent/android/src/main/java/com/reactnativereceivesharingintent/ReceiveSharingIntentModule.java
 @@ -18,6 +18,7 @@ public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
@@ -10,7 +171,7 @@ index f752144..725918a 100644
  
    public ReceiveSharingIntentModule(ReactApplicationContext reactContext) {
      super(reactContext);
-@@ -30,6 +31,7 @@ public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
+@@ -30,18 +31,24 @@ public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
    protected void onNewIntent(Intent intent) {
      Activity mActivity = getCurrentActivity();
      if(mActivity == null) { return; }
@@ -18,17 +179,30 @@ index f752144..725918a 100644
      mActivity.setIntent(intent);
    }
  
-@@ -40,7 +42,9 @@ public class ReceiveSharingIntentModule extends ReactContextBaseJavaModule {
-     if(mActivity == null) { return; }
-     Intent intent = mActivity.getIntent();
-     receiveSharingIntentHelper.sendFileNames(reactContext, intent, promise);
+   @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+-  @ReactMethod
+-  public void getFileNames(Promise promise){
+-    Activity mActivity = getCurrentActivity();
+-    if(mActivity == null) { return; }
+-    Intent intent = mActivity.getIntent();
+-    receiveSharingIntentHelper.sendFileNames(reactContext, intent, promise);
 -    mActivity.setIntent(null);
-+    if (oldIntent != null) {
-+      mActivity.setIntent(oldIntent);
-+    }  
++@ReactMethod
++public void getFileNames(Promise promise) {
++  Activity mActivity = getCurrentActivity();
++  if (mActivity == null) {
++    promise.reject();
++    return;
++  }
++  Intent intent = mActivity.getIntent();
++  receiveSharingIntentHelper.sendFileNames(reactContext, intent, promise);
++  if (oldIntent != null) {
++    mActivity.setIntent(oldIntent);
    }
++}
  
    @ReactMethod
+   public void clearFileNames(){
 diff --git a/node_modules/react-native-receive-sharing-intent/src/ReceiveSharingIntent.ts b/node_modules/react-native-receive-sharing-intent/src/ReceiveSharingIntent.ts
 index 735c191..91dab4b 100644
 --- a/node_modules/react-native-receive-sharing-intent/src/ReceiveSharingIntent.ts

--- a/patches/react-native-receive-sharing-intent+2.0.0.patch
+++ b/patches/react-native-receive-sharing-intent+2.0.0.patch
@@ -19,13 +19,13 @@ index 69126eb..b15059a 100644
 +    String action = intent.getAction();
 +    String type = intent.getType();
 +    if(type == null) { 
-+      promise.reject();
++      promise.reject("error", "Type is null");
 +      return; 
 +    }
 +    if(!type.startsWith("text") && (Objects.equals(action, Intent.ACTION_SEND) || Objects.equals(action, Intent.ACTION_SEND_MULTIPLE))){
 +      WritableMap files = getMediaUris(intent,context);
 +      if(files == null) {
-+        promise.reject();
++        promise.reject("error", "Files is null");
 +        return;
 +      }
 +      promise.resolve(files);
@@ -69,7 +69,7 @@ index 69126eb..b15059a 100644
 -          files.putMap("0",file);
 -          promise.resolve(files);
 +        if(files == null) {
-+          promise.reject();
++          promise.reject("error", "Files is null");
 +          return;
          }
 -
@@ -149,11 +149,11 @@ index 69126eb..b15059a 100644
 +      files.putMap("0", file);
 +      promise.resolve(files);
 +    }else{
-+      promise.reject();
++      promise.reject("error","Invalid file type.");
      }
 -  };
 +  }catch (Exception e){
-+    promise.reject();
++    promise.reject("error",e.toString());
 +  }
 +};
  
@@ -191,7 +191,7 @@ index f752144..f0bd892 100644
 +public void getFileNames(Promise promise) {
 +  Activity mActivity = getCurrentActivity();
 +  if (mActivity == null) {
-+    promise.reject();
++    promise.reject("ACTIVITY_NULL", "Activity is null");
 +    return;
 +  }
 +  Intent intent = mActivity.getIntent();

--- a/patches/react-native-receive-sharing-intent+2.0.0.patch
+++ b/patches/react-native-receive-sharing-intent+2.0.0.patch
@@ -19,8 +19,11 @@ index 69126eb..b15059a 100644
 +    String action = intent.getAction();
 +    String type = intent.getType();
 +    if(type == null) { 
-+      promise.reject("error", "Type is null");
-+      return; 
++      WritableMap intentState = Arguments.createMap();
++      WritableArray emptyArray = Arguments.createArray();
++      intentState.putArray("intent", emptyArray);
++      promise.resolve(intentState);
++      return;
 +    }
 +    if(!type.startsWith("text") && (Objects.equals(action, Intent.ACTION_SEND) || Objects.equals(action, Intent.ACTION_SEND_MULTIPLE))){
 +      WritableMap files = getMediaUris(intent,context);


### PR DESCRIPTION
When using actual patch, on Android i get a lot of warning due to promise not handle correctly inside `react-native-action-receive-sharing-intent`. 

> ` Please report: Excessive number of pending callbacks: 501. Some pending callbacks that might have leaked by never being called from native code: {"208":{"module":"ReceiveSharingIntent","method":"getFileNames"},"3428":{"module":"ReceiveSharingIntent","method":"getFileNames"},"21703":{},"21707":{},"21711":{},"21715":{},"21719":{},"21723":{},"21727":{},"21731":{},"21735":{},"21739":{},"21743":{},"21747":{},"21751":{},"21755":{},"21759":{},"21763":{},"21767":{},"21771":{},"21775":{},"21779":{},"21783":{},"21787":{},"21791":{},"21795":{},"21799":{},"21803":{},"21807":{},"21811":{},"21815":{},"21819":{},"21823":{},"21827":{},"21831":{},"21835":{},"21839":{},"21843":{},"21847":{},"21851":{},"21855":{},"21859":{},"21863":{},"21867":{},"21871":{},"21875":{},"21879":{},"21883":{},"21887":{},"21891":{},"...(truncated keys)...":451}`

I updated it to handle promise correctly and structure a little. 